### PR TITLE
Fix 'php:' directory appearing

### DIFF
--- a/src/system/io/log.php
+++ b/src/system/io/log.php
@@ -23,7 +23,7 @@ class log
         self::factoryConstruct($configSection);
         $config = $this->getPackageConfig();
         parent::__construct($config['name']);
-        $directory = dirname($config['path']);
+        $directory = parse_url($config['path'], PHP_URL_PATH);
         if(!file_exists($directory)) {
             $status = @mkdir($directory, 0777, true);
             if($status === false) {

--- a/src/system/io/log.php
+++ b/src/system/io/log.php
@@ -23,16 +23,20 @@ class log
         self::factoryConstruct($configSection);
         $config = $this->getPackageConfig();
         parent::__construct($config['name']);
-        $directory = parse_url($config['path'], PHP_URL_PATH);
-        if(!file_exists($directory)) {
-            $status = @mkdir($directory, 0777, true);
-            if($status === false) {
-                $config['path'] = sys_get_temp_dir() . '/mpcmf.' . posix_getpid() .'.log';
-                $this->addCritical("Log directory creation failed, use new path instead of original. New path: {$config['path']}");
+        $urlPath = parse_url($config['path'], PHP_URL_PATH);
+        if (!is_null($urlPath)) {
+            $directory = dirname($urlPath);
+            if(!file_exists($directory)) {
+                $status = @mkdir($directory, 0777, true);
+                if($status === false) {
+                    $config['path'] = sys_get_temp_dir() . '/mpcmf.' . posix_getpid() .'.log';
+                    $this->addCritical("Log directory creation failed, use new path instead of original. New path: {$config['path']}");
+                }
+            } elseif(!is_writable($directory)) {
+                @chmod($directory, 0777);
             }
-        } elseif(!is_writable($directory)) {
-            @chmod($directory, 0777);
         }
+        
         $this->pushHandler(new StreamHandler($config['path'], $config['level']));
         MPCMF_DEBUG && $this->addDebug("New log created: {$this->configSection}");
     }

--- a/src/system/io/log.php
+++ b/src/system/io/log.php
@@ -30,7 +30,7 @@ class log
                 $config['path'] = sys_get_temp_dir() . '/mpcmf.' . posix_getpid() .'.log';
                 $this->addCritical("Log directory creation failed, use new path instead of original. New path: {$config['path']}");
             }
-        } elseif(is_writable($directory)) {
+        } elseif(!is_writable($directory)) {
             @chmod($directory, 0777);
         }
         $this->pushHandler(new StreamHandler($config['path'], $config['level']));


### PR DESCRIPTION
When the path in the logging path started with `php://` (`php://stdout`, `php://stderr`, etc), `dirname($config['path'])` returned `'php:'`, leading to the creation of a php: directory in the current working directory. By parsing the path parameter as an URL, this is fixed now :)

(also fixes a bug so that directories are actually made writable if they're not, and not the other way round)