### PR TITLE
Add optional log colors based on log level

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     "wingu/code-generator": "1.0.5",
     "phpmailer/phpmailer": "~6.0",
     "monolog/monolog": "~1.12",
+    "bramus/monolog-colored-line-formatter": "~2.0",
     "khr/react-curl": "dev-master",
     "infostars/net-curl": "dev-master",
     "smarty/smarty": "3.1.27",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "43e542a46e621990815e552ff22a93c3",
+    "content-hash": "6f90bc0649e1691f8404d7d383243076",
     "packages": [
         {
             "name": "alcaeus/mongo-php-adapter",
@@ -70,6 +70,88 @@
                 "mongodb"
             ],
             "time": "2018-08-06T06:00:52+00:00"
+        },
+        {
+            "name": "bramus/ansi-php",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bramus/ansi-php.git",
+                "reference": "79d30c30651b0c6f23cf85503c779c72ac74ab8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bramus/ansi-php/zipball/79d30c30651b0c6f23cf85503c779c72ac74ab8a",
+                "reference": "79d30c30651b0c6f23cf85503c779c72ac74ab8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Bramus\\Ansi\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bramus Van Damme",
+                    "email": "bramus@bram.us",
+                    "homepage": "https://www.bram.us/"
+                }
+            ],
+            "description": "ANSI Control Functions and ANSI Control Sequences (Colors, Erasing, etc.) for PHP CLI Apps",
+            "time": "2019-02-12T15:05:30+00:00"
+        },
+        {
+            "name": "bramus/monolog-colored-line-formatter",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bramus/monolog-colored-line-formatter.git",
+                "reference": "6bff15eee00afe2690642535b0f1541f10852c2b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bramus/monolog-colored-line-formatter/zipball/6bff15eee00afe2690642535b0f1541f10852c2b",
+                "reference": "6bff15eee00afe2690642535b0f1541f10852c2b",
+                "shasum": ""
+            },
+            "require": {
+                "bramus/ansi-php": "~3.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "monolog/monolog": "~1.0",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Bramus\\Monolog\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bramus Van Damme",
+                    "email": "bramus@bram.us",
+                    "homepage": "https://www.bram.us/"
+                }
+            ],
+            "description": "Colored Line Formatter for Monolog",
+            "time": "2015-01-07T22:12:35+00:00"
         },
         {
             "name": "infostars/net-curl",

--- a/src/system/io/log.php
+++ b/src/system/io/log.php
@@ -2,6 +2,7 @@
 
 namespace mpcmf\system\io;
 
+use Bramus\Monolog\Formatter\ColoredLineFormatter;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use mpcmf\system\pattern\factory;
@@ -37,7 +38,13 @@ class log
             }
         }
         
-        $this->pushHandler(new StreamHandler($config['path'], $config['level']));
+        $handler = new StreamHandler($config['path'], $config['level']);
+
+        if (isset($config['colorOutput']) && $config['colorOutput'] === true)
+            $handler->setFormatter(new ColoredLineFormatter());
+
+        $this->pushHandler($handler);
+
         MPCMF_DEBUG && $this->addDebug("New log created: {$this->configSection}");
     }
 }


### PR DESCRIPTION
Adding `'colorOutput' => true` to the log config (mpcmf_system_io_log.php) will enable this.

Example: 
<img width="490" alt="image" src="https://user-images.githubusercontent.com/2780577/58645885-7d7d9200-8304-11e9-9397-553ffed8f928.png">
