### PR TITLE
[MCORE-19] remove leading backslash used for PHP5.3 compatibility

### DIFF
--- a/src/system/configuration/config.php
+++ b/src/system/configuration/config.php
@@ -115,8 +115,7 @@ class config
         static $classNamesCached = [];
 
         if(!isset($classNamesCached[$packageName])) {
-            $classNamesCached[$packageName] = self::NAMESPACE_SEPARATOR
-                . str_replace(self::CONFIG_SEPARATOR, self::NAMESPACE_SEPARATOR, $packageName);
+            $classNamesCached[$packageName] = str_replace(self::CONFIG_SEPARATOR, self::NAMESPACE_SEPARATOR, $packageName);
         }
 
         return $classNamesCached[$packageName];


### PR DESCRIPTION
Resolves #19

From new composer removed workaround for https://bugs.php.net/50731
![image](https://user-images.githubusercontent.com/11310253/89463658-ed44a380-d777-11ea-8074-f020f0460abe.png)