### PR TITLE
[mongoInstance] fix incorrect logging when checking indexes

### DIFF
--- a/src/system/storage/mongoInstance.php
+++ b/src/system/storage/mongoInstance.php
@@ -390,7 +390,7 @@ class mongoInstance
             $log->addDebug('Checking index ' . json_encode($index));
             $needToCreate[$key] = true;
             foreach ($dbIndexes as $dbIndex) {
-                if (json_encode($dbIndex['key']) === json_encode($index['keys'])) {
+                if ($dbIndex['key'] === $index['keys']) {
                     $log->addDebug('Found index ' . json_encode($index['keys']) . ', checking options...');
                     if (!empty($index['options'])) {
                         $log->addDebug('Options in cfg found');

--- a/src/system/storage/mongoInstance.php
+++ b/src/system/storage/mongoInstance.php
@@ -390,7 +390,7 @@ class mongoInstance
             $log->addDebug('Checking index ' . json_encode($index));
             $needToCreate[$key] = true;
             foreach ($dbIndexes as $dbIndex) {
-                if ($dbIndex['key'] === $index['keys']) {
+                if (json_encode($dbIndex['key']) === json_encode($index['keys'])) {
                     $log->addDebug('Found index ' . json_encode($index['keys']) . ', checking options...');
                     if (!empty($index['options'])) {
                         $log->addDebug('Options in cfg found');


### PR DESCRIPTION
`checkIndexes` says in log that indexes do not exist, when they actually do.

example collection:
```shell
> use test
switched to db test
> db.test.getIndexes()
[
        {
                "v" : 1,
                "key" : {
                        "_id" : 1
                },
                "name" : "_id_",
                "ns" : "test.test"
        },
        {
                "v" : 1,
                "unique" : true,
                "key" : {
                        "foo" : 1
                },
                "name" : "foo_1",
                "ns" : "test.test"
        },
        {
                "v" : 1,
                "key" : {
                        "bar" : ""
                },
                "name" : "bar_",
                "ns" : "test.test"
        },
        {
                "v" : 1,
                "key" : {
                        "baz" : ""
                },
                "name" : "baz_",
                "ns" : "test.test"
        }
]
```
code:
```php
$mongo = mongoInstance::factory();
$indexes = [
    [
        'keys' => [
            'foo' => 1
        ],
        'options' => [
            'unique' => true,
        ]
    ],
    [
        'keys' => [
            'bar' => ''
        ],
    ],
    [
        'keys' => [
            'baz' => ''
        ],
    ],
];
$mongo->checkIndexes('test', 'test', $indexes);
```
output:
```
[2020-09-30 10:30:18] BaseLog.DEBUG: Checking indexes for `test` [] []
[2020-09-30 10:30:18] BaseLog.DEBUG: Checking index {"keys":{"foo":1},"options":{"unique":true}} [] []
[2020-09-30 10:30:18] BaseLog.INFO: Not found index {"keys":{"foo":1},"options":{"unique":true}} [] []
[2020-09-30 10:30:18] BaseLog.DEBUG: Found index {"foo":1}, checking options... [] []
[2020-09-30 10:30:18] BaseLog.DEBUG: Options in cfg found [] []
[2020-09-30 10:30:18] BaseLog.DEBUG: Index OK, skipping... [] []
[2020-09-30 10:30:18] BaseLog.DEBUG: Checking index {"keys":{"bar":""}} [] []
[2020-09-30 10:30:18] BaseLog.INFO: Not found index {"keys":{"bar":""}} [] []
[2020-09-30 10:30:18] BaseLog.INFO: Not found index {"keys":{"bar":""}} [] []
[2020-09-30 10:30:18] BaseLog.DEBUG: Found index {"bar":""}, checking options... [] []
[2020-09-30 10:30:18] BaseLog.DEBUG: Options in cfg not found, Index OK, skipping... [] []
[2020-09-30 10:30:18] BaseLog.DEBUG: Checking index {"keys":{"baz":""}} [] []
[2020-09-30 10:30:18] BaseLog.INFO: Not found index {"keys":{"baz":""}} [] []
[2020-09-30 10:30:18] BaseLog.INFO: Not found index {"keys":{"baz":""}} [] []
[2020-09-30 10:30:18] BaseLog.INFO: Not found index {"keys":{"baz":""}} [] []
[2020-09-30 10:30:18] BaseLog.DEBUG: Found index {"baz":""}, checking options... [] []
[2020-09-30 10:30:18] BaseLog.DEBUG: Options in cfg not found, Index OK, skipping... [] []
[2020-09-30 10:30:18] BaseLog.INFO: Need to create indexes: 0 [] []
```

Expected output:
```
[2020-09-30 10:37:26] BaseLog.DEBUG: Checking indexes for `test` [] []
[2020-09-30 10:37:26] BaseLog.DEBUG: Checking index {"keys":{"foo":1},"options":{"unique":true}} [] []
[2020-09-30 10:37:26] BaseLog.DEBUG: Found index {"foo":1}, checking options... [] []
[2020-09-30 10:37:26] BaseLog.DEBUG: Options in cfg found [] []
[2020-09-30 10:37:26] BaseLog.DEBUG: Index OK, skipping... [] []
[2020-09-30 10:37:26] BaseLog.DEBUG: Checking index {"keys":{"bar":""}} [] []
[2020-09-30 10:37:26] BaseLog.DEBUG: Found index {"bar":""}, checking options... [] []
[2020-09-30 10:37:26] BaseLog.DEBUG: Options in cfg not found, Index OK, skipping... [] []
[2020-09-30 10:37:26] BaseLog.DEBUG: Checking index {"keys":{"baz":""}} [] []
[2020-09-30 10:37:26] BaseLog.DEBUG: Found index {"baz":""}, checking options... [] []
[2020-09-30 10:37:26] BaseLog.DEBUG: Options in cfg not found, Index OK, skipping... [] []
[2020-09-30 10:37:26] BaseLog.INFO: Need to create indexes: 0 [] []
```
