### PR TITLE
define APP_ROOT

### DIFF
--- a/src/loader.php
+++ b/src/loader.php
@@ -11,6 +11,7 @@ namespace mpcmf;
 
 use Composer\Autoload\ClassLoader;
 use mpcmf\system\cache\cache;
+use mpcmf\system\configuration\config;
 
 class loader
 {
@@ -34,7 +35,7 @@ class loader
         $loader = self::getLoader();
 
         if (!defined('APP_ROOT')) {
-            define('APP_ROOT', realpath(__DIR__ . '/../../../../'));
+            define('APP_ROOT', config::getProjectRoot());
         }
 
         $map = require APP_ROOT . '/vendor/composer/autoload_namespaces.php';

--- a/src/loader.php
+++ b/src/loader.php
@@ -33,6 +33,10 @@ class loader
 
         $loader = self::getLoader();
 
+        if (!defined('APP_ROOT')) {
+            define('APP_ROOT', realpath(__DIR__ . '/../../../../'));
+        }
+
         $map = require APP_ROOT . '/vendor/composer/autoload_namespaces.php';
         foreach ($map as $namespace => $path) {
             $loader->set($namespace, $path);

--- a/src/system/configuration/config.php
+++ b/src/system/configuration/config.php
@@ -52,7 +52,7 @@ class config
      * @return string
      * @throws configurationException
      */
-    protected static function getProjectRoot()
+    public static function getProjectRoot()
     {
         static $projectRoot;
 


### PR DESCRIPTION
```json
"autoload": {
    "psr-4": {
      "mpcmf\\system\\": "src/system/"
    },
    "files": [
      "src/loader.php"
    ]
  }
  ```
Т.к loader.php подключен в автолоадер композера, приложения из вендора падают с фатальной ошибкой из-за необъявленной константы APP_ROOT


Например:
```sh
[saitkulov@localhost mpcmf]$  /opt/src/mpcmf/vendor/phpunit/phpunit/phpunit
PHP Warning:  Use of undefined constant APP_ROOT - assumed 'APP_ROOT' (this will throw an Error in a future version of PHP) in /opt/src/mpcmf/vendor/mpcmf/mpcmf-core/src/loader.php on line 36
PHP Stack trace:
PHP   1. {main}() /opt/src/mpcmf/vendor/phpunit/phpunit/phpunit:0
PHP   2. require() /opt/src/mpcmf/vendor/phpunit/phpunit/phpunit:90
PHP   3. ComposerAutoloaderInit6501d55a76ebad91701c552dfda6ca01::getLoader() /opt/src/mpcmf/vendor/autoload.php:7
PHP   4. composerRequire6501d55a76ebad91701c552dfda6ca01() /opt/src/mpcmf/vendor/composer/autoload_real.php:63
PHP   5. require() /opt/src/mpcmf/vendor/composer/autoload_real.php:73
PHP   6. mpcmf\loader::load() /opt/src/mpcmf/vendor/mpcmf/mpcmf-core/src/loader.php:98
PHP Warning:  require(APP_ROOT/vendor/composer/autoload_namespaces.php): failed to open stream: No such file or directory in /opt/src/mpcmf/vendor/mpcmf/mpcmf-core/src/loader.php on line 36
PHP Stack trace:
PHP   1. {main}() /opt/src/mpcmf/vendor/phpunit/phpunit/phpunit:0
PHP   2. require() /opt/src/mpcmf/vendor/phpunit/phpunit/phpunit:90
PHP   3. ComposerAutoloaderInit6501d55a76ebad91701c552dfda6ca01::getLoader() /opt/src/mpcmf/vendor/autoload.php:7
PHP   4. composerRequire6501d55a76ebad91701c552dfda6ca01() /opt/src/mpcmf/vendor/composer/autoload_real.php:63
PHP   5. require() /opt/src/mpcmf/vendor/composer/autoload_real.php:73
PHP   6. mpcmf\loader::load() /opt/src/mpcmf/vendor/mpcmf/mpcmf-core/src/loader.php:98
PHP Fatal error:  require(): Failed opening required 'APP_ROOT/vendor/composer/autoload_namespaces.php' (include_path='/opt/src/mpcmf/vendor/google/apiclient/src:.:/usr/share/pear:/usr/share/php') in /opt/src/mpcmf/vendor/mpcmf/mpcmf-core/src/loader.php on line 36
PHP Stack trace:
PHP   1. {main}() /opt/src/mpcmf/vendor/phpunit/phpunit/phpunit:0
PHP   2. require() /opt/src/mpcmf/vendor/phpunit/phpunit/phpunit:90
PHP   3. ComposerAutoloaderInit6501d55a76ebad91701c552dfda6ca01::getLoader() /opt/src/mpcmf/vendor/autoload.php:7
PHP   4. composerRequire6501d55a76ebad91701c552dfda6ca01() /opt/src/mpcmf/vendor/composer/autoload_real.php:63
PHP   5. require() /opt/src/mpcmf/vendor/composer/autoload_real.php:73
PHP   6. mpcmf\loader::load() /opt/src/mpcmf/vendor/mpcmf/mpcmf-core/src/loader.php:98
```