### PR TITLE
crud create form: link to relation mapper

### DIFF
--- a/src/system/modules/moduleBase/templates/crud/create.tpl
+++ b/src/system/modules/moduleBase/templates/crud/create.tpl
@@ -16,7 +16,11 @@
                 <td>
                     {if $field.formType=='select' || $field.formType=='searchebleselect'}
                         {assign var="relationMapper" value=$_entity->getMapper()->getRelationMapper($fieldName)}
-                        <a href="{$_application->getUrl("/{$relationMapper->getModuleName()}/{$relationMapper->getEntityName()}/crud.list", [])}">{$field.name}</a>
+                        {if $relationMapper->getEntityActions()->getAction('crud.list') !== false}
+                            <a href="{$_application->getUrl("/{$relationMapper->getModuleName()}/{$relationMapper->getEntityName()}/crud.list", [])}">{$field.name}</a>
+                        {else}
+                            {$field.name}
+                        {/if}
                     {else}
                         {$field.name}
                     {/if}

--- a/src/system/modules/moduleBase/templates/crud/create.tpl
+++ b/src/system/modules/moduleBase/templates/crud/create.tpl
@@ -13,18 +13,7 @@
         <tbody>
         {foreach from=$_entity->getMapper()->getMap() key="fieldName" item="field"}
             <tr>
-                <td>
-                    {if $field.formType=='select' || $field.formType=='searchebleselect'}
-                        {assign var="relationMapper" value=$_entity->getMapper()->getRelationMapper($fieldName)}
-                        {if $relationMapper->getEntityActions()->getAction('crud.list') !== false}
-                            <a href="{$_application->getUrl("/{$relationMapper->getModuleName()}/{$relationMapper->getEntityName()}/crud.list", [])}">{$field.name}</a>
-                        {else}
-                            {$field.name}
-                        {/if}
-                    {else}
-                        {$field.name}
-                    {/if}
-                </td>
+                <td>{include file="forms/generate/field_title.tpl" field=$field}</td>
                 {if isset($data.item)}
                     <td>{include file="forms/generate/type_{$field.formType}.tpl" fieldName=$fieldName field=$field item=$data.item}</td>
                 {else}

--- a/src/system/modules/moduleBase/templates/crud/create.tpl
+++ b/src/system/modules/moduleBase/templates/crud/create.tpl
@@ -28,11 +28,11 @@
                 {/if}
             </tr>
         {/foreach}
-        <tr>
-            <td colspan="2">
-                {include file="forms/generate/type_submit.tpl"}
-            </td>
-        </tr>
+            <tr>
+                <td colspan="2">
+                    {include file="forms/generate/type_submit.tpl"}
+                </td>
+            </tr>
         </tbody>
     </table>
 </form>

--- a/src/system/modules/moduleBase/templates/crud/create.tpl
+++ b/src/system/modules/moduleBase/templates/crud/create.tpl
@@ -13,7 +13,14 @@
         <tbody>
         {foreach from=$_entity->getMapper()->getMap() key="fieldName" item="field"}
             <tr>
-                <td>{$field.name}</td>
+                <td>
+                    {if $field.formType=='select' || $field.formType=='searchebleselect'}
+                        {assign var="relationMapper" value=$_entity->getMapper()->getRelationMapper($fieldName)}
+                        <a href="{$_application->getUrl("/{$relationMapper->getModuleName()}/{$relationMapper->getEntityName()}/crud.list", [])}">{$field.name}</a>
+                    {else}
+                        {$field.name}
+                    {/if}
+                </td>
                 {if isset($data.item)}
                     <td>{include file="forms/generate/type_{$field.formType}.tpl" fieldName=$fieldName field=$field item=$data.item}</td>
                 {else}
@@ -21,11 +28,11 @@
                 {/if}
             </tr>
         {/foreach}
-            <tr>
-                <td colspan="2">
-                    {include file="forms/generate/type_submit.tpl"}
-                </td>
-            </tr>
+        <tr>
+            <td colspan="2">
+                {include file="forms/generate/type_submit.tpl"}
+            </td>
+        </tr>
         </tbody>
     </table>
 </form>

--- a/src/system/modules/moduleBase/templates/crud/get.tpl
+++ b/src/system/modules/moduleBase/templates/crud/get.tpl
@@ -15,18 +15,7 @@
     <tbody>
     {foreach from=$_entity->getMapper()->getMap() key="fieldName" item="field"}
         <tr>
-            <td>
-                {if $field.formType=='select' || $field.formType=='searchebleselect'}
-                    {assign var="relationMapper" value=$_entity->getMapper()->getRelationMapper($fieldName)}
-                    {if $relationMapper->getEntityActions()->getAction('crud.list') !== false}
-                        <a href="{$_application->getUrl("/{$relationMapper->getModuleName()}/{$relationMapper->getEntityName()}/crud.list", [])}">{$field.name}</a>
-                    {else}
-                        {$field.name}
-                    {/if}
-                {else}
-                    {$field.name}
-                {/if}
-            </td>
+            <td>{include file="forms/generate/field_title.tpl" field=$field}</td>
             {if isset($data.item)}
                 <td>{include file="forms/generate/type_{$field.formType}.tpl" fieldName=$fieldName field=$field item=$data.item readonly=true}</td>
             {else}

--- a/src/system/modules/moduleBase/templates/crud/get.tpl
+++ b/src/system/modules/moduleBase/templates/crud/get.tpl
@@ -15,7 +15,18 @@
     <tbody>
     {foreach from=$_entity->getMapper()->getMap() key="fieldName" item="field"}
         <tr>
-            <td>{$field.name}</td>
+            <td>
+                {if $field.formType=='select' || $field.formType=='searchebleselect'}
+                    {assign var="relationMapper" value=$_entity->getMapper()->getRelationMapper($fieldName)}
+                    {if $relationMapper->getEntityActions()->getAction('crud.list') !== false}
+                        <a href="{$_application->getUrl("/{$relationMapper->getModuleName()}/{$relationMapper->getEntityName()}/crud.list", [])}">{$field.name}</a>
+                    {else}
+                        {$field.name}
+                    {/if}
+                {else}
+                    {$field.name}
+                {/if}
+            </td>
             {if isset($data.item)}
                 <td>{include file="forms/generate/type_{$field.formType}.tpl" fieldName=$fieldName field=$field item=$data.item readonly=true}</td>
             {else}

--- a/src/system/modules/moduleBase/templates/crud/update.tpl
+++ b/src/system/modules/moduleBase/templates/crud/update.tpl
@@ -20,7 +20,11 @@
                 <td>
                     {if $field.formType=='select' || $field.formType=='searchebleselect'}
                         {assign var="relationMapper" value=$_entity->getMapper()->getRelationMapper($fieldName)}
-                        <a href="{$_application->getUrl("/{$relationMapper->getModuleName()}/{$relationMapper->getEntityName()}/crud.list", [])}">{$field.name}</a>
+                        {if $relationMapper->getEntityActions()->getAction('crud.list') !== false}
+                            <a href="{$_application->getUrl("/{$relationMapper->getModuleName()}/{$relationMapper->getEntityName()}/crud.list", [])}">{$field.name}</a>
+                        {else}
+                            {$field.name}
+                        {/if}
                     {else}
                         {$field.name}
                     {/if}

--- a/src/system/modules/moduleBase/templates/crud/update.tpl
+++ b/src/system/modules/moduleBase/templates/crud/update.tpl
@@ -17,7 +17,14 @@
         <tbody>
         {foreach from=$_entity->getMapper()->getMap() key="fieldName" item="field"}
             <tr>
-                <td>{$field.name}</td>
+                <td>
+                    {if $field.formType=='select' || $field.formType=='searchebleselect'}
+                        {assign var="relationMapper" value=$_entity->getMapper()->getRelationMapper($fieldName)}
+                        <a href="{$_application->getUrl("/{$relationMapper->getModuleName()}/{$relationMapper->getEntityName()}/crud.list", [])}">{$field.name}</a>
+                    {else}
+                        {$field.name}
+                    {/if}
+                </td>
                 {if isset($data.item)}
                     <td>{include file="forms/generate/type_{$field.formType}.tpl" fieldName=$fieldName field=$field item=$data.item}</td>
                 {else}

--- a/src/system/modules/moduleBase/templates/crud/update.tpl
+++ b/src/system/modules/moduleBase/templates/crud/update.tpl
@@ -17,18 +17,7 @@
         <tbody>
         {foreach from=$_entity->getMapper()->getMap() key="fieldName" item="field"}
             <tr>
-                <td>
-                    {if $field.formType=='select' || $field.formType=='searchebleselect'}
-                        {assign var="relationMapper" value=$_entity->getMapper()->getRelationMapper($fieldName)}
-                        {if $relationMapper->getEntityActions()->getAction('crud.list') !== false}
-                            <a href="{$_application->getUrl("/{$relationMapper->getModuleName()}/{$relationMapper->getEntityName()}/crud.list", [])}">{$field.name}</a>
-                        {else}
-                            {$field.name}
-                        {/if}
-                    {else}
-                        {$field.name}
-                    {/if}
-                </td>
+                <td>{include file="forms/generate/field_title.tpl" field=$field}</td>
                 {if isset($data.item)}
                     <td>{include file="forms/generate/type_{$field.formType}.tpl" fieldName=$fieldName field=$field item=$data.item}</td>
                 {else}

--- a/src/system/modules/moduleBase/templates/forms/generate/field_title.tpl
+++ b/src/system/modules/moduleBase/templates/forms/generate/field_title.tpl
@@ -1,0 +1,10 @@
+{if $field.formType=='select' || $field.formType=='searchebleselect'}
+    {assign var="relationMapper" value=$_entity->getMapper()->getRelationMapper($fieldName)}
+    {if $relationMapper->getEntityActions()->getAction('crud.list') !== false}
+        <a href="{$_application->getUrl("/{$relationMapper->getModuleName()}/{$relationMapper->getEntityName()}/crud.list", [])}">{$field.name}</a>
+    {else}
+        {$field.name}
+    {/if}
+{else}
+    {$field.name}
+{/if}


### PR DESCRIPTION
in crud create form, if field is `select` or `searchebleselect`, render field name as clickable link to related mapper